### PR TITLE
(BREAKING)Rename procedure module to orderexpansion module

### DIFF
--- a/.github/workflows/CI-publish.yml
+++ b/.github/workflows/CI-publish.yml
@@ -1,4 +1,4 @@
-name: CI for Openmrs-module-procedures
+name: CI for Openmrs-module-orderexpansion
 on:
   push:
     branches: [ main, 2.x ]
@@ -18,18 +18,18 @@ jobs:
         command_timeout: 200m
         script: |
           cd /apps/github-workflows/kenyaemr-modules
-          sudo rm -rf openmrs-module-procedures
-          sudo mkdir openmrs-module-procedures
-          sudo chown -R cicd2:cicd2 openmrs-module-procedures
-          git config --global --add safe.directory /apps/github-workflows/kenyaemr-modules/openmrs-module-procedures
-          cd /apps/github-workflows/kenyaemr-modules/openmrs-module-procedures
-          git clone -b 2.x https://github.com/palladiumkenya/openmrs-module-procedures.git /apps/github-workflows/kenyaemr-modules/openmrs-module-procedures
-          sudo chown -R cicd2:cicd2 /apps/github-workflows/kenyaemr-modules/openmrs-module-procedures
+          sudo rm -rf openmrs-module-orderexpansion
+          sudo mkdir openmrs-module-orderexpansion
+          sudo chown -R cicd2:cicd2 openmrs-module-orderexpansion
+          git config --global --add safe.directory /apps/github-workflows/kenyaemr-modules/openmrs-module-orderexpansion
+          cd /apps/github-workflows/kenyaemr-modules/openmrs-module-orderexpansion
+          git clone -b 2.x https://github.com/palladiumkenya/openmrs-module-orderexpansion.git /apps/github-workflows/kenyaemr-modules/openmrs-module-orderexpansion
+          sudo chown -R cicd2:cicd2 /apps/github-workflows/kenyaemr-modules/openmrs-module-orderexpansion
           git status
           mvn license:format
           sudo mvn clean install -DskipTests
-          sudo rm -rf /var/lib/OpenMRS/modules/procedures-*.omod
-          sudo cp -r /apps/github-workflows/kenyaemr-modules/openmrs-module-procedures/omod/target/procedures-*.omod /var/lib/OpenMRS/modules/
+          sudo rm -rf /var/lib/OpenMRS/modules/orderexpansion-*.omod
+          sudo cp -r /apps/github-workflows/kenyaemr-modules/openmrs-module-orderexpansion/omod/target/orderexpansion-*.omod /var/lib/OpenMRS/modules/
           sudo chown -R tomcat:tomcat /var/lib/OpenMRS/modules/
           sudo chmod +r /var/lib/OpenMRS/modules/*.omod
           sudo chmod 755 /var/lib/OpenMRS/modules/*.omod
@@ -51,17 +51,17 @@ jobs:
         command_timeout: 200m
         script: |
           cd /apps/githubworkflows/kenyaemr-modules
-          sudo rm -rf openmrs-module-procedures
-          sudo mkdir openmrs-module-procedures
-          sudo chown -R cicd:cicd openmrs-module-procedures
-          git config --global --add safe.directory /apps/githubworkflows/kenyaemr-modules/openmrs-module-procedures
-          cd /apps/githubworkflows/kenyaemr-modules/openmrs-module-procedures
-          git clone -b main https://github.com/palladiumkenya/openmrs-module-procedures.git .
+          sudo rm -rf openmrs-module-orderexpansion
+          sudo mkdir openmrs-module-orderexpansion
+          sudo chown -R cicd:cicd openmrs-module-orderexpansion
+          git config --global --add safe.directory /apps/githubworkflows/kenyaemr-modules/openmrs-module-orderexpansion
+          cd /apps/githubworkflows/kenyaemr-modules/openmrs-module-orderexpansion
+          git clone -b main https://github.com/palladiumkenya/openmrs-module-orderexpansion.git .
           git status
           mvn license:format
           sudo mvn clean install -DskipTests
-          sudo rm -rf /var/lib/OpenMRS/modules/procedures*.omod
-          sudo cp -r /apps/githubworkflows/kenyaemr-modules/openmrs-module-procedures/omod/target/procedures-*.omod /var/lib/OpenMRS/modules/
+          sudo rm -rf /var/lib/OpenMRS/modules/orderexpansion*.omod
+          sudo cp -r /apps/githubworkflows/kenyaemr-modules/openmrs-module-orderexpansion/omod/target/orderexpansion-*.omod /var/lib/OpenMRS/modules/
           sudo chown -R tomcat:tomcat /var/lib/OpenMRS/modules/
           sudo chmod +r /var/lib/OpenMRS/modules/*.omod
           sudo chmod 755 /var/lib/OpenMRS/modules/*.omod

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,11 +3,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.openmrs.module</groupId>
-		<artifactId>procedures</artifactId>
+		<artifactId>orderexpansion</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>procedures-api</artifactId>
+	<artifactId>orderexpansion-api</artifactId>
 	<packaging>jar</packaging>
 	<name>Procedure Module API</name>
 	<description>API project for Procedure Module</description>

--- a/api/src/main/java/org/openmrs/module/orderexpansion/ProceduresActivator.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/ProceduresActivator.java
@@ -11,7 +11,7 @@
  *
  * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
  */
-package org.openmrs.module.procedures;
+package org.openmrs.module.orderexpansion;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/MedicalSupplyDispenseService.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/MedicalSupplyDispenseService.java
@@ -1,8 +1,8 @@
-package org.openmrs.module.procedures.api;
+package org.openmrs.module.orderexpansion.api;
 
 import java.util.Optional;
 
-import org.openmrs.module.procedures.api.model.MedicalSupplyDispense;
+import org.openmrs.module.orderexpansion.api.model.MedicalSupplyDispense;
 import org.springframework.lang.NonNull;
 
 public interface MedicalSupplyDispenseService {

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/ProcedureService.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/ProcedureService.java
@@ -1,10 +1,10 @@
-package org.openmrs.module.procedures.api;
+package org.openmrs.module.orderexpansion.api;
 
 import javax.validation.constraints.NotNull;
 
 import java.util.Optional;
 
-import org.openmrs.module.procedures.api.model.Procedure;
+import org.openmrs.module.orderexpansion.api.model.Procedure;
 
 public interface ProcedureService {
 	

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/MedicalSupplyDispenseDao.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/MedicalSupplyDispenseDao.java
@@ -1,10 +1,10 @@
-package org.openmrs.module.procedures.api.dao;
+package org.openmrs.module.orderexpansion.api.dao;
 
 import javax.validation.constraints.NotNull;
 
 import java.util.Optional;
 
-import org.openmrs.module.procedures.api.model.MedicalSupplyDispense;
+import org.openmrs.module.orderexpansion.api.model.MedicalSupplyDispense;
 
 public interface MedicalSupplyDispenseDao {
 	

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/ProcedureDao.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/ProcedureDao.java
@@ -1,10 +1,10 @@
-package org.openmrs.module.procedures.api.dao;
+package org.openmrs.module.orderexpansion.api.dao;
 
 import javax.validation.constraints.NotNull;
 
 import java.util.Optional;
 
-import org.openmrs.module.procedures.api.model.Procedure;
+import org.openmrs.module.orderexpansion.api.model.Procedure;
 
 public interface ProcedureDao {
 	

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/impl/MedicalSupplyDispenseDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/impl/MedicalSupplyDispenseDaoImpl.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.api.dao.impl;
+package org.openmrs.module.orderexpansion.api.dao.impl;
 
 import static org.hibernate.criterion.Restrictions.eq;
 
@@ -7,8 +7,8 @@ import java.util.Optional;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.openmrs.module.procedures.api.dao.MedicalSupplyDispenseDao;
-import org.openmrs.module.procedures.api.model.MedicalSupplyDispense;
+import org.openmrs.module.orderexpansion.api.dao.MedicalSupplyDispenseDao;
+import org.openmrs.module.orderexpansion.api.model.MedicalSupplyDispense;
 
 public class MedicalSupplyDispenseDaoImpl implements MedicalSupplyDispenseDao {
 	

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/impl/ProcedureDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/dao/impl/ProcedureDaoImpl.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.api.dao.impl;
+package org.openmrs.module.orderexpansion.api.dao.impl;
 
 import static org.hibernate.criterion.Restrictions.eq;
 
@@ -7,8 +7,8 @@ import java.util.Optional;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.openmrs.module.procedures.api.dao.ProcedureDao;
-import org.openmrs.module.procedures.api.model.Procedure;
+import org.openmrs.module.orderexpansion.api.dao.ProcedureDao;
+import org.openmrs.module.orderexpansion.api.model.Procedure;
 
 public class ProcedureDaoImpl implements ProcedureDao {
 	

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/impl/MedicalSupplyDispenseServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/impl/MedicalSupplyDispenseServiceImpl.java
@@ -1,12 +1,12 @@
-package org.openmrs.module.procedures.api.impl;
+package org.openmrs.module.orderexpansion.api.impl;
 
 import javax.transaction.Transactional;
 
 import java.util.Optional;
 
-import org.openmrs.module.procedures.api.MedicalSupplyDispenseService;
-import org.openmrs.module.procedures.api.dao.MedicalSupplyDispenseDao;
-import org.openmrs.module.procedures.api.model.MedicalSupplyDispense;
+import org.openmrs.module.orderexpansion.api.MedicalSupplyDispenseService;
+import org.openmrs.module.orderexpansion.api.dao.MedicalSupplyDispenseDao;
+import org.openmrs.module.orderexpansion.api.model.MedicalSupplyDispense;
 
 @Transactional
 public class MedicalSupplyDispenseServiceImpl implements MedicalSupplyDispenseService {

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/impl/ProcedureServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/impl/ProcedureServiceImpl.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.api.impl;
+package org.openmrs.module.orderexpansion.api.impl;
 
 import javax.transaction.Transactional;
 
@@ -13,9 +13,9 @@ import org.openmrs.EncounterProvider;
 import org.openmrs.Obs;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.procedures.api.ProcedureService;
-import org.openmrs.module.procedures.api.dao.ProcedureDao;
-import org.openmrs.module.procedures.api.model.Procedure;
+import org.openmrs.module.orderexpansion.api.ProcedureService;
+import org.openmrs.module.orderexpansion.api.dao.ProcedureDao;
+import org.openmrs.module.orderexpansion.api.model.Procedure;
 
 @Transactional
 public class ProcedureServiceImpl implements ProcedureService {

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/model/MedicalSupplyDispense.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/model/MedicalSupplyDispense.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.api.model;
+package org.openmrs.module.orderexpansion.api.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/model/MedicalSupplyOrder.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/model/MedicalSupplyOrder.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.api.model;
+package org.openmrs.module.orderexpansion.api.model;
 
 import org.openmrs.ServiceOrder;
 

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/model/Procedure.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/model/Procedure.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.api.model;
+package org.openmrs.module.orderexpansion.api.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/api/src/main/java/org/openmrs/module/orderexpansion/api/model/ProcedureOrder.java
+++ b/api/src/main/java/org/openmrs/module/orderexpansion/api/model/ProcedureOrder.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.procedures.api.model;
+package org.openmrs.module.orderexpansion.api.model;
 
 import java.util.Set;
 

--- a/api/src/main/resources/MedicalSupplyOrder.hbm.xml
+++ b/api/src/main/resources/MedicalSupplyOrder.hbm.xml
@@ -4,7 +4,7 @@
         "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
-    <joined-subclass name="org.openmrs.module.procedures.api.model.MedicalSupplyOrder" extends="org.openmrs.Order" table="medical_supplies_order" lazy="false">
+    <joined-subclass name="org.openmrs.module.orderexpansion.api.model.MedicalSupplyOrder" extends="org.openmrs.Order" table="medical_supplies_order" lazy="false">
 
         <key column="order_id" not-null="true" on-delete="cascade" />
         <property name="medicalSuppliesInventoryId" type="int" column="medical_supplies_inventory_id" length="11" />

--- a/api/src/main/resources/ProcedureOrder.hbm.xml
+++ b/api/src/main/resources/ProcedureOrder.hbm.xml
@@ -4,7 +4,7 @@
         "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
-    <joined-subclass name="org.openmrs.module.procedures.api.model.ProcedureOrder" extends="org.openmrs.Order" table="procedure_order" lazy="false">
+    <joined-subclass name="org.openmrs.module.orderexpansion.api.model.ProcedureOrder" extends="org.openmrs.Order" table="procedure_order" lazy="false">
 
         <key column="order_id" not-null="true" on-delete="cascade" />
 
@@ -23,10 +23,10 @@
         <many-to-one name="frequency" class="org.openmrs.OrderFrequency" />
         <many-to-one name="location" class="org.openmrs.Concept" />
 
-        <many-to-one name="relatedProcedure" class="org.openmrs.module.procedures.api.model.ProcedureOrder"  column="related_procedure_id"/>
+        <many-to-one name="relatedProcedure" class="org.openmrs.module.orderexpansion.api.model.ProcedureOrder"  column="related_procedure_id"/>
         <set name="procedures" table="procedures" inverse="true" cascade="all">
             <key column="procedure_order_id"/>
-            <one-to-many class="org.openmrs.module.procedures.api.model.Procedure"/>
+            <one-to-many class="org.openmrs.module.orderexpansion.api.model.Procedure"/>
         </set>
     </joined-subclass>
 </hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -103,9 +103,14 @@
     </changeSet>
 
     <changeSet id="${project.parent.artifactId}-2024031419999" author="jecihjoy">
-        <preConditions onFail="MARK_RAN">
+       <preConditions onFail="MARK_RAN">
+        <and>
             <tableExists tableName="procedures"/>
-        </preConditions>
+            <not>
+                <columnExists tableName="procedures" columnName="modality"/>
+            </not>
+        </and>
+    </preConditions>
         <addColumn tableName="procedures">
             <column name="modality" type="int"/>
         </addColumn>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -21,13 +21,13 @@
     which set audit info like dateCreated, changedBy, etc.-->
 
     <context:annotation-config/>
-    <context:component-scan base-package="org.openmrs.module.procedures" />
+    <context:component-scan base-package="org.openmrs.module.orderexpansion" />
 
     <bean id="procedureService"
           class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
         <property name="transactionManager" ref="transactionManager"/>
         <property name="target">
-            <bean class="org.openmrs.module.procedures.api.impl.ProcedureServiceImpl">
+            <bean class="org.openmrs.module.orderexpansion.api.impl.ProcedureServiceImpl">
                 <property name="procedureDao" ref="procedureDao"/>
             </bean>
         </property>
@@ -35,7 +35,7 @@
         <property name="transactionAttributeSource" ref="transactionAttributeSource"/>
     </bean>
 
-    <bean id="procedureDao" class="org.openmrs.module.procedures.api.dao.impl.ProcedureDaoImpl">
+    <bean id="procedureDao" class="org.openmrs.module.orderexpansion.api.dao.impl.ProcedureDaoImpl">
         <property name="sessionFactory">
             <ref bean="sessionFactory"/>
         </property>
@@ -43,7 +43,7 @@
      <bean parent="serviceContext">
         <property name="moduleService">
             <list>
-                <value>org.openmrs.module.procedures.api.ProcedureService</value>
+                <value>org.openmrs.module.orderexpansion.api.ProcedureService</value>
                 <ref bean="procedureService"/>
             </list>
         </property>
@@ -53,7 +53,7 @@
           class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
         <property name="transactionManager" ref="transactionManager"/>
         <property name="target">
-            <bean class="org.openmrs.module.procedures.api.impl.MedicalSupplyDispenseServiceImpl">
+            <bean class="org.openmrs.module.orderexpansion.api.impl.MedicalSupplyDispenseServiceImpl">
                 <property name="medicalSupplyDispenseDao" ref="medicalSupplyDispenseDao"/>
             </bean>
         </property>
@@ -61,7 +61,7 @@
         <property name="transactionAttributeSource" ref="transactionAttributeSource"/>
     </bean>
 
-    <bean id="medicalSupplyDispenseDao" class="org.openmrs.module.procedures.api.dao.impl.MedicalSupplyDispenseDaoImpl">
+    <bean id="medicalSupplyDispenseDao" class="org.openmrs.module.orderexpansion.api.dao.impl.MedicalSupplyDispenseDaoImpl">
         <property name="sessionFactory">
             <ref bean="sessionFactory"/>
         </property>
@@ -70,7 +70,7 @@
     <bean parent="serviceContext">
         <property name="moduleService">
             <list>
-                <value>org.openmrs.module.procedures.api.MedicalSupplyDispenseService</value>
+                <value>org.openmrs.module.orderexpansion.api.MedicalSupplyDispenseService</value>
                 <ref bean="medicalSupplyDispenseService"/>
             </list>
         </property>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -3,19 +3,18 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.openmrs.module</groupId>
-		<artifactId>procedures</artifactId>
+		<artifactId>orderexpansion</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>procedures-omod</artifactId>
+	<artifactId>orderexpansion-omod</artifactId>
 	<packaging>jar</packaging>
-	<name>Procedure Module OMOD</name>
-	<description>OpenMRS module project for Procedure Module</description>
-
+	<name>Order Expansion Module OMOD</name>
+	<description>OpenMRS module for management of order extension</description>
 	<dependencies>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
-			<artifactId>procedures-api</artifactId>
+			<artifactId>orderexpansion-api</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>

--- a/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/MedicalSupplyDispenseResource.java
+++ b/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/MedicalSupplyDispenseResource.java
@@ -1,10 +1,10 @@
-package org.openmrs.module.procedures.web.resources;
+package org.openmrs.module.orderexpansion.web.resources;
 
 import java.util.Optional;
 
 import org.openmrs.api.context.Context;
-import org.openmrs.module.procedures.api.MedicalSupplyDispenseService;
-import org.openmrs.module.procedures.api.model.MedicalSupplyDispense;
+import org.openmrs.module.orderexpansion.api.MedicalSupplyDispenseService;
+import org.openmrs.module.orderexpansion.api.model.MedicalSupplyDispense;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;

--- a/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/MedicalSupplyOrderSubclassHandler.java
+++ b/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/MedicalSupplyOrderSubclassHandler.java
@@ -1,27 +1,12 @@
-/**
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
- * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
- * <p>
- * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
- * graphic logo is a trademark of OpenMRS Inc.
- */
-package org.openmrs.module.procedures.web.resources;
-
-import java.util.ArrayList;
-import java.util.List;
+package org.openmrs.module.orderexpansion.web.resources;
 
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import org.openmrs.Order;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.procedures.api.model.Procedure;
-import org.openmrs.module.procedures.api.model.ProcedureOrder;
-import org.openmrs.module.webservices.docs.swagger.core.property.EnumProperty;
+import org.openmrs.module.orderexpansion.api.model.MedicalSupplyOrder;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
@@ -36,12 +21,12 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubclassHandler;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 
-@SubClassHandler(supportedClass = ProcedureOrder.class, supportedOpenmrsVersions = { "2.6.* - 9.*" })
-public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler<Order, ProcedureOrder> implements DelegatingSubclassHandler<Order, ProcedureOrder> {
+@SubClassHandler(supportedClass = MedicalSupplyOrder.class, supportedOpenmrsVersions = { "2.6.* - 9.*" })
+public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHandler<Order, MedicalSupplyOrder> implements DelegatingSubclassHandler<Order, MedicalSupplyOrder> {
 	
 	@Override
 	public String getTypeName() {
-		return "procedureorder";
+		return "medicalsupplyorder";
 	}
 	
 	@Override
@@ -50,8 +35,8 @@ public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler
 	}
 	
 	@Override
-	public ProcedureOrder newDelegate() {
-		return new ProcedureOrder();
+	public MedicalSupplyOrder newDelegate() {
+		return new MedicalSupplyOrder();
 	}
 	
 	@Override
@@ -62,7 +47,7 @@ public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler
 	}
 	
 	@PropertyGetter("display")
-	public static String getDisplay(ProcedureOrder delegate) {
+	public static String getDisplay(MedicalSupplyOrder delegate) {
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		return orderResource.getDisplayString(delegate);
@@ -74,29 +59,19 @@ public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler
 			OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 			        .getResourceBySupportedClass(Order.class);
 			DelegatingResourceDescription d = orderResource.getRepresentationDescription(rep);
-			d.addProperty("specimenSource", Representation.REF);
-			d.addProperty("laterality");
-			d.addProperty("clinicalHistory");
-			d.addProperty("frequency", Representation.REF);
-			d.addProperty("numberOfRepeats");
-			d.addProperty("specimenType", Representation.REF);
-			d.addProperty("bodySite", Representation.REF);
-			d.addProperty("relatedProcedure", Representation.REF);
-			d.addProperty("procedures", Representation.REF);
+			d.addProperty("quantity", Representation.REF);
+			d.addProperty("medicalSuppliesInventoryId");
+			d.addProperty("brandName");
+			d.addProperty("quantityUnits", Representation.REF);
 			return d;
 		} else if (rep instanceof FullRepresentation) {
 			OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 			        .getResourceBySupportedClass(Order.class);
 			DelegatingResourceDescription d = orderResource.getRepresentationDescription(rep);
-			d.addProperty("specimenSource", Representation.FULL);
-			d.addProperty("laterality");
-			d.addProperty("clinicalHistory");
-			d.addProperty("frequency", Representation.DEFAULT);
-			d.addProperty("numberOfRepeats");
-			d.addProperty("specimenType", Representation.FULL);
-			d.addProperty("bodySite", Representation.FULL);
-			d.addProperty("relatedProcedure", Representation.FULL);
-			d.addProperty("procedures", Representation.FULL);
+			d.addProperty("quantity", Representation.FULL);
+			d.addProperty("medicalSuppliesInventoryId");
+			d.addProperty("brandName");
+			d.addProperty("quantityUnits", Representation.DEFAULT);
 			return d;
 		} else if (rep instanceof CustomRepresentation) { // custom rep
 			return null;
@@ -104,33 +79,15 @@ public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler
 		return null;
 	}
 	
-	@PropertyGetter(value = "procedures")
-	public List<Procedure> getProcedures(ProcedureOrder instance) {
-		try {
-			List<Procedure> procedures = new ArrayList<>(instance.getProcedures());
-			return procedures;
-		}
-		catch (Exception e) {
-			return new ArrayList<>();
-		}
-	}
-	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		DelegatingResourceDescription d = orderResource.getCreatableProperties();
-		d.addProperty("specimenSource");
-		d.addProperty("laterality");
-		d.addProperty("clinicalHistory");
-		d.addProperty("frequency");
-		d.addProperty("numberOfRepeats");
-		d.addProperty("orderType");
-		d.addProperty("bodySite");
-		d.addProperty("specimenType");
-		d.addProperty("commentToFulfiller");
-		d.addProperty("scheduledDate");
-		d.addProperty("relatedProcedure");
+		d.addProperty("quantity");
+		d.addProperty("medicalSuppliesInventoryId");
+		d.addProperty("brandName");
+		d.addProperty("quantityUnits");
 		return d;
 	}
 	
@@ -139,16 +96,9 @@ public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		ModelImpl orderModel = (ModelImpl) orderResource.getGETModel(rep);
-		orderModel.property("laterality", new EnumProperty(ProcedureOrder.Laterality.class))
-		        .property("clinicalHistory", new StringProperty()).property("numberOfRepeats", new IntegerProperty());
+		orderModel.property("medicalSuppliesInventoryId", new StringProperty()).property("quantity", new IntegerProperty())
+		        .property("brandName", new StringProperty()).property("quantityUnits", new StringProperty());
 		
-		if (rep instanceof DefaultRepresentation) {
-			orderModel.property("specimenSource", new RefProperty("#/definitions/ConceptGetRef")).property("frequency",
-			    new RefProperty("#/definitions/OrderfrequencyGetRef"));
-		} else if (rep instanceof FullRepresentation) {
-			orderModel.property("specimenSource", new RefProperty("#/definitions/ConceptGet")).property("frequency",
-			    new RefProperty("#/definitions/OrderfrequencyGet"));
-		}
 		return orderModel;
 	}
 	
@@ -157,11 +107,9 @@ public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		ModelImpl orderModel = (ModelImpl) orderResource.getCREATEModel(rep);
-		return orderModel.property("specimenSource", new StringProperty().example("uuid"))
-		        .property("laterality", new EnumProperty(ProcedureOrder.Laterality.class))
-		        .property("clinicalHistory", new StringProperty())
-		        .property("frequency", new StringProperty().example("uuid"))
-		        .property("numberOfRepeats", new IntegerProperty());
+		return orderModel.property("medicalSuppliesInventoryId", new StringProperty().example("uuid"))
+		        .property("quantityUnits", new StringProperty()).property("brandName", new StringProperty())
+		        .property("quantity", new IntegerProperty());
 	}
 	
 }

--- a/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/OrderResource2_3.java
+++ b/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/OrderResource2_3.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.web.resources;
+package org.openmrs.module.orderexpansion.web.resources;
 
 import org.openmrs.DrugOrder;
 import org.openmrs.Order;
@@ -7,8 +7,8 @@ import org.openmrs.ReferralOrder;
 import org.openmrs.TestOrder;
 import org.openmrs.api.OrderContext;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.procedures.api.model.MedicalSupplyOrder;
-import org.openmrs.module.procedures.api.model.ProcedureOrder;
+import org.openmrs.module.orderexpansion.api.model.MedicalSupplyOrder;
+import org.openmrs.module.orderexpansion.api.model.ProcedureOrder;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_2.OrderResource2_2;

--- a/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/ProcedureOrderSubclassHandler.java
+++ b/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/ProcedureOrderSubclassHandler.java
@@ -1,12 +1,27 @@
-package org.openmrs.module.procedures.web.resources;
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * <p>
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.orderexpansion.web.resources;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import org.openmrs.Order;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.procedures.api.model.MedicalSupplyOrder;
+import org.openmrs.module.orderexpansion.api.model.Procedure;
+import org.openmrs.module.orderexpansion.api.model.ProcedureOrder;
+import org.openmrs.module.webservices.docs.swagger.core.property.EnumProperty;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
@@ -21,12 +36,12 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubclassHandler;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 
-@SubClassHandler(supportedClass = MedicalSupplyOrder.class, supportedOpenmrsVersions = { "2.6.* - 9.*" })
-public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHandler<Order, MedicalSupplyOrder> implements DelegatingSubclassHandler<Order, MedicalSupplyOrder> {
+@SubClassHandler(supportedClass = ProcedureOrder.class, supportedOpenmrsVersions = { "2.6.* - 9.*" })
+public class ProcedureOrderSubclassHandler extends BaseDelegatingSubclassHandler<Order, ProcedureOrder> implements DelegatingSubclassHandler<Order, ProcedureOrder> {
 	
 	@Override
 	public String getTypeName() {
-		return "medicalsupplyorder";
+		return "procedureorder";
 	}
 	
 	@Override
@@ -35,8 +50,8 @@ public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHan
 	}
 	
 	@Override
-	public MedicalSupplyOrder newDelegate() {
-		return new MedicalSupplyOrder();
+	public ProcedureOrder newDelegate() {
+		return new ProcedureOrder();
 	}
 	
 	@Override
@@ -47,7 +62,7 @@ public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHan
 	}
 	
 	@PropertyGetter("display")
-	public static String getDisplay(MedicalSupplyOrder delegate) {
+	public static String getDisplay(ProcedureOrder delegate) {
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		return orderResource.getDisplayString(delegate);
@@ -59,19 +74,29 @@ public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHan
 			OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 			        .getResourceBySupportedClass(Order.class);
 			DelegatingResourceDescription d = orderResource.getRepresentationDescription(rep);
-			d.addProperty("quantity", Representation.REF);
-			d.addProperty("medicalSuppliesInventoryId");
-			d.addProperty("brandName");
-			d.addProperty("quantityUnits", Representation.REF);
+			d.addProperty("specimenSource", Representation.REF);
+			d.addProperty("laterality");
+			d.addProperty("clinicalHistory");
+			d.addProperty("frequency", Representation.REF);
+			d.addProperty("numberOfRepeats");
+			d.addProperty("specimenType", Representation.REF);
+			d.addProperty("bodySite", Representation.REF);
+			d.addProperty("relatedProcedure", Representation.REF);
+			d.addProperty("procedures", Representation.REF);
 			return d;
 		} else if (rep instanceof FullRepresentation) {
 			OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 			        .getResourceBySupportedClass(Order.class);
 			DelegatingResourceDescription d = orderResource.getRepresentationDescription(rep);
-			d.addProperty("quantity", Representation.FULL);
-			d.addProperty("medicalSuppliesInventoryId");
-			d.addProperty("brandName");
-			d.addProperty("quantityUnits", Representation.DEFAULT);
+			d.addProperty("specimenSource", Representation.FULL);
+			d.addProperty("laterality");
+			d.addProperty("clinicalHistory");
+			d.addProperty("frequency", Representation.DEFAULT);
+			d.addProperty("numberOfRepeats");
+			d.addProperty("specimenType", Representation.FULL);
+			d.addProperty("bodySite", Representation.FULL);
+			d.addProperty("relatedProcedure", Representation.FULL);
+			d.addProperty("procedures", Representation.FULL);
 			return d;
 		} else if (rep instanceof CustomRepresentation) { // custom rep
 			return null;
@@ -79,15 +104,33 @@ public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHan
 		return null;
 	}
 	
+	@PropertyGetter(value = "procedures")
+	public List<Procedure> getProcedures(ProcedureOrder instance) {
+		try {
+			List<Procedure> procedures = new ArrayList<>(instance.getProcedures());
+			return procedures;
+		}
+		catch (Exception e) {
+			return new ArrayList<>();
+		}
+	}
+	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		DelegatingResourceDescription d = orderResource.getCreatableProperties();
-		d.addProperty("quantity");
-		d.addProperty("medicalSuppliesInventoryId");
-		d.addProperty("brandName");
-		d.addProperty("quantityUnits");
+		d.addProperty("specimenSource");
+		d.addProperty("laterality");
+		d.addProperty("clinicalHistory");
+		d.addProperty("frequency");
+		d.addProperty("numberOfRepeats");
+		d.addProperty("orderType");
+		d.addProperty("bodySite");
+		d.addProperty("specimenType");
+		d.addProperty("commentToFulfiller");
+		d.addProperty("scheduledDate");
+		d.addProperty("relatedProcedure");
 		return d;
 	}
 	
@@ -96,9 +139,16 @@ public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHan
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		ModelImpl orderModel = (ModelImpl) orderResource.getGETModel(rep);
-		orderModel.property("medicalSuppliesInventoryId", new StringProperty()).property("quantity", new IntegerProperty())
-		        .property("brandName", new StringProperty()).property("quantityUnits", new StringProperty());
+		orderModel.property("laterality", new EnumProperty(ProcedureOrder.Laterality.class))
+		        .property("clinicalHistory", new StringProperty()).property("numberOfRepeats", new IntegerProperty());
 		
+		if (rep instanceof DefaultRepresentation) {
+			orderModel.property("specimenSource", new RefProperty("#/definitions/ConceptGetRef")).property("frequency",
+			    new RefProperty("#/definitions/OrderfrequencyGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			orderModel.property("specimenSource", new RefProperty("#/definitions/ConceptGet")).property("frequency",
+			    new RefProperty("#/definitions/OrderfrequencyGet"));
+		}
 		return orderModel;
 	}
 	
@@ -107,9 +157,11 @@ public class MedicalSupplyOrderSubclassHandler extends BaseDelegatingSubclassHan
 		OrderResource2_3 orderResource = (OrderResource2_3) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		ModelImpl orderModel = (ModelImpl) orderResource.getCREATEModel(rep);
-		return orderModel.property("medicalSuppliesInventoryId", new StringProperty().example("uuid"))
-		        .property("quantityUnits", new StringProperty()).property("brandName", new StringProperty())
-		        .property("quantity", new IntegerProperty());
+		return orderModel.property("specimenSource", new StringProperty().example("uuid"))
+		        .property("laterality", new EnumProperty(ProcedureOrder.Laterality.class))
+		        .property("clinicalHistory", new StringProperty())
+		        .property("frequency", new StringProperty().example("uuid"))
+		        .property("numberOfRepeats", new IntegerProperty());
 	}
 	
 }

--- a/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/ProcedureResource.java
+++ b/omod/src/main/java/org/openmrs/module/orderexpansion/web/resources/ProcedureResource.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.web.resources;
+package org.openmrs.module.orderexpansion.web.resources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,8 +6,8 @@ import java.util.Optional;
 
 import org.openmrs.Encounter;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.procedures.api.ProcedureService;
-import org.openmrs.module.procedures.api.model.Procedure;
+import org.openmrs.module.orderexpansion.api.ProcedureService;
+import org.openmrs.module.orderexpansion.api.model.Procedure;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;

--- a/omod/src/main/java/org/openmrs/module/orderexpansion/web/search/ConceptSearchHandler2_6.java
+++ b/omod/src/main/java/org/openmrs/module/orderexpansion/web/search/ConceptSearchHandler2_6.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.procedures.web.search;
+package org.openmrs.module.orderexpansion.web.search;
 
 import java.util.Collections;
 import java.util.List;

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -6,13 +6,13 @@
 	<id>${project.parent.artifactId}</id>
 	<name>${project.parent.name}</name>
 	<version>${project.parent.version}</version>
-	<package>org.openmrs.module.procedures</package>
+	<package>org.openmrs.module.orderexpansion</package>
 	<author>jecihjoy</author>
 	<description>
 		${project.parent.description}
 	</description>
 
-	<activator>org.openmrs.module.procedures.ProceduresActivator</activator>
+	<activator>org.openmrs.module.orderexpansion.ProceduresActivator</activator>
 
 	<require_version>2.0.5 - 2.*</require_version>
 

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -22,7 +22,7 @@
 
 	<!-- Add here beans related to the web context -->
 
-	<context:component-scan base-package="org.openmrs.module.procedures.web" />
+	<context:component-scan base-package="org.openmrs.module.orderexpansion.web" />
  
 		
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.openmrs.module</groupId>
-	<artifactId>procedures</artifactId>
+	<artifactId>orderexpansion</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
-	<name>Procedures Module</name>
-	<description>OpenMRS module for management of procedures.</description>
+	<name>Order Expansion Module</name>
+	<description>OpenMRS module for management of order extension</description>
 
 
 	<scm>


### PR DESCRIPTION
This PR intend to make procedure module to have a generic name since the same module is now going to be used to handle `Radiology, Procedures and Medical supply`.

Once this PR is merge I will also rename the repository to `openmrs-module-orderexpansion` 
Also, going forward we are not using `procedure omod`  but to use orderexpansion omod